### PR TITLE
Upgraded miopen/sqlite3 package.txt to 3.50.4 to match recipes/sqlite3.

### DIFF
--- a/miopen/sqlite3/3.50.4/package.txt
+++ b/miopen/sqlite3/3.50.4/package.txt
@@ -1,0 +1,1 @@
+https://www.sqlite.org/2025/sqlite-autoconf-3500400.tar.gz -H sha256:a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18 -X autotools


### PR DESCRIPTION
## Motivation

Upgrading miopen/sqlite3 package.txt to 3.50.4 to match recipes/sqlite3.

## Technical Details

This is mirroring the upgrade to 3.49.1 changes.  See: https://github.com/ROCm/rocm-recipes/pull/11